### PR TITLE
fix: dynamically resize window height based on selected monitor aspect ratio

### DIFF
--- a/TopNotify/GUI/MainCommands.cs
+++ b/TopNotify/GUI/MainCommands.cs
@@ -41,7 +41,7 @@ namespace TopNotify.GUI
                 .Show();
         }
 
-        [Command("Donate")] 
+        [Command("Donate")]
         public static async void Donate()
         {
             try
@@ -68,7 +68,7 @@ namespace TopNotify.GUI
         {
             // Read version from Appx Manifest
             var appxManifest = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "AppxManifest.xml");
-            if (File.Exists(appxManifest)) { 
+            if (File.Exists(appxManifest)) {
                 var manifestData = File.ReadAllText(appxManifest);
 
                 var from = manifestData.IndexOf("Version=\"") + "Version=\"".Length;
@@ -86,6 +86,17 @@ namespace TopNotify.GUI
         [Command("RequestConfig")]
         public static void RequestConfig(WebWindow target)
         {
+            // Calculate window height based on preview aspect ratio
+            var resolution = ResolutionFinder.GetRealResolution();
+            float aspect = (float)resolution.Height / resolution.Width;
+
+            // Preview width is 352px, so preview height = 352 * aspect
+            // Add fixed UI height for header, dropdown, controls, buttons, and padding
+            float previewHeight = 352f * aspect;
+            float windowHeight = previewHeight + 420f;
+
+            target.Bounds = new WindowBounds((int)(400f * ResolutionFinder.GetScale()), (int)(windowHeight * ResolutionFinder.GetScale()));
+
             target.SendConfig();
         }
 


### PR DESCRIPTION
When a portrait-oriented monitor is selected, the preview area consumes
most of the fixed 650px window height, pushing controls out of view.

This fix calculates the window height dynamically based on the selected
monitor's aspect ratio:
- Window height = (352 × aspect ratio) + 420px padding
- The 352px matches the preview width used in Preview.jsx
- The 420px accounts for header, dropdown, controls, and buttons

The window now resizes automatically when switching between landscape
and portrait monitors in the dropdown.

Fixes SamsidParty/TopNotify#91